### PR TITLE
console functions handling

### DIFF
--- a/generators/app/templates/common/gulpfile.babel.js
+++ b/generators/app/templates/common/gulpfile.babel.js
@@ -113,7 +113,7 @@ export function buildScripts() {
         .pipe(buffer())
         .pipe(uglify({
             compress: {
-                drop_console: true,
+                pure_funcs: ["console.log"],
             },
         }))
         .pipe(gulp.dest(paths.scripts.dest));

--- a/generators/app/templates/static/js/index.js
+++ b/generators/app/templates/static/js/index.js
@@ -28,6 +28,18 @@ const ready = (callbackFunc) => {
  * Document ready callback
  */
 ready(() => {
+    var credits = [
+        "background-color: #000000",
+        "color: white",
+        "display: block",
+        "line-height: 24px",
+        "text-align: center",
+        "border: 1px solid #ffffff",
+        "font-weight: bold",
+    ].join(";");
+
+    console.info("dev by: %c Bornfight ", credits);
+
     const dummy = new Dummy();
     dummy.init();
 


### PR DESCRIPTION
Updated how console.log function is handled. Uglify config now uses
pure_funcs property to exclude console.logs. Uglify preserves other
console functions, e.g. console.info for credits purposes,
connsole.error for missing DOM elements etc.