### PR TITLE
Custom transition function (new feature)

### DIFF
--- a/generators/app/templates/static/scss/tools/_tools.transitions.scss
+++ b/generators/app/templates/static/scss/tools/_tools.transitions.scss
@@ -23,9 +23,66 @@
 ) {
     @if (map-has_key($settings-transitions, $transitionName)) {
         @return map-get($settings-transitions, $transitionName)
-            getTransitionEasing($transitionEasing);
+        getTransitionEasing($transitionEasing);
     } @else {
         @return map-get($settings-transitions, "default")
-            getTransitionEasing($transitionEasing);
+        getTransitionEasing($transitionEasing);
     }
+}
+
+/**
+ * Custom transition function
+ * used when you need to specify custom transition for only one or multiple properties but not all
+ * if you will not change the property use getTransition instead
+ * default easing is from getTransitionEasing
+ * @param {string} $transitions - any number of transitions
+ * usage:
+ * transition: getCustomTransition(opacity);
+ * transition: getCustomTransition(transform 0.3s);
+ * transition: getCustomTransition(transform 0.5s ease, background-color 0.2s);
+ * transition: getCustomTransition(
+ *                  top 0.3s cubic-bezier(0.23, 1, 0.32, 1),
+ *                  transform 0.3s cubic-bezier(0.23, 1, 0.32, 1) 0.3s
+ *               );
+ */
+@function getCustomTransition($transitions...) {
+    $unfoldedTransitions: ();
+    @each $transition in $transitions {
+        $unfoldedTransitions: append(
+                        $unfoldedTransitions,
+                        unfoldTransition($transition),
+                        comma
+        );
+    }
+    @return $unfoldedTransitions;
+}
+
+/**
+ * Unfold transition function
+ * Helper for getCustomTransition();
+ * Takes any number of arguments passed to getCustomTransition() and makes unfolds them to single properties
+ * 1. Transition property defaults
+ * 2. Grab transition properties if they exist
+ */
+@function unfoldTransition($transition) {
+    /* 1 */
+    $property: all;
+    $duration: 0.2s;
+    $easing: getTransitionEasing();
+    $delay: null;
+    $defaultProperties: ($property, $duration, $easing, $delay);
+
+    /* 2 */
+    $unfoldedTransition: ();
+    @for $i from 1 through length($defaultProperties) {
+        $p: null;
+        @if $i <= length($transition) {
+            $p: nth($transition, $i);
+        } @else {
+            $p: nth($defaultProperties, $i);
+        }
+        $unfoldedTransition: append($unfoldedTransition, $p);
+    }
+
+    @return $unfoldedTransition;
 }


### PR DESCRIPTION
# Description

Added new function for custom transitions, when you don't want to apply transition to all properties because of javascript animations or because of performance, or if you need to specify multiple transitions with different options. Default options are the same as for getTransition function, so not specifying easing or duration will fallback to our defaults. 

Example usage: 

`transition: getCustomTransition(transform 0.5s ease, background-color 0.2s);`

output: 

`transition: transform 0.5s ease, background-color 0.2s cubic-bezier(0.55, 0.085, 0.68, 0.53), -webkit-transform 0.5s ease;`

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested and used on chavd-web-2020

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes