### PR TITLE
b-creative - add webP convert support for images

### DIFF
--- a/generators/app/templates/common/gulpfile.babel.js
+++ b/generators/app/templates/common/gulpfile.babel.js
@@ -13,6 +13,7 @@ import sourcemaps from "gulp-sourcemaps";
 import source from "vinyl-source-stream";
 import uglify from "gulp-uglify";
 import watchify from "watchify";
+import webp from "gulp-webp";
 import { plugins } from "./plugins";
 
 /**
@@ -28,6 +29,10 @@ const paths = {
         main: "static/js/index.js",
         src: "static/js/**/*.js",
         dest: "static/dist/",
+    },
+    images: {
+        src: "static/images/**/*.{jpg,jpeg,png}",
+        dest: "static/images/webp/",
     },
     markup: {
         src: "**/*.{html,php}",
@@ -191,6 +196,15 @@ export function buildVendorScripts() {
 }
 
 /**
+ * Convert images to WebP format
+ */
+export function convertWebPImages() {
+    return gulp.src(paths.images.src)
+        .pipe(webp())
+        .pipe(gulp.dest(paths.images.dest));
+}
+
+/**
  * Reload task
  */
 export function reload(done) {
@@ -228,6 +242,11 @@ const watch = gulp.series(
     serve,
     watchFiles,
 );
+
+/**
+ * WebP convert task
+ */
+export const webPImages = gulp.series(convertWebPImages);
 
 /**
  * Build task

--- a/generators/app/templates/common/package.json
+++ b/generators/app/templates/common/package.json
@@ -14,7 +14,8 @@
     "dev": "NODE_ENV='development' gulp",
     "esdoc": "./node_modules/.bin/esdoc",
     "format": "prettier --write 'static/**/*.{scss,js}'",
-    "lint:scss": "stylelint 'static/**/*.scss'"
+    "lint:scss": "stylelint 'static/**/*.scss'",
+    "webp": "gulp webPImages"
   },
   "browserslist": [
     "> 0.5%",
@@ -22,7 +23,7 @@
   ],
   "dependencies": {
     "@bornfight/b-reset": "^1.0.4",
-    "gsap": "^3.2.6",
+    "gsap": "^3.3.3",
     "poly-fluid-sizing": "^1.1.0"
   },
   "devDependencies": {
@@ -39,9 +40,9 @@
     "del": "^5.1.0",
     "esdoc": "^1.1.0",
     "esdoc-standard-plugin": "^1.0.0",
-    "eslint": "^7.1.0",
+    "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-prettier": "^3.1.4",
     "esm": "^3.2.25",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^7.0.1",
@@ -53,8 +54,9 @@
     "gulp-sass": "^4.1.0",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.2",
+    "gulp-webp": "^4.0.1",
     "prettier": "^2.0.5",
-    "stylelint": "^13.5.0",
+    "stylelint": "^13.6.0",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-prettier": "^1.1.2",
     "stylelint-scss": "^3.17.2",


### PR DESCRIPTION
# Description

Gulp task to convert images to webP format. Task takes all `jpg`, `jpeg` and `png` images and convert them to webp format. Optimised images are separated in `webp` folder inside `images` folder. 

### Performance testing
Test images are optimised without losing informations and with almost half the size.

<img width="408" alt="Screenshot 2020-06-16 at 23 32 49" src="https://user-images.githubusercontent.com/11228203/84833579-e3cc7400-b02f-11ea-8c79-e562be74f15b.png">

### Project usage
WebP format must be used only with picture element to add fallback for browser not still supporting this format.

```
<picture>
  <source srcset="static/images/webp/image.webp" type="image/webp">
  <source srcset="static/images/image.jpg" type="image/jpeg"> 
  <img src="static/images/image.jpg" alt="Alt">
</picture>
```

### Task usage

Task is not part of any build or watch series, only manual running. 
Task can be runned with `npm run webp` .

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works