### PR TITLE
fixed deprecated npm modules

### DIFF
--- a/generators/app/templates/common/package.json
+++ b/generators/app/templates/common/package.json
@@ -13,8 +13,8 @@
     },
     "devDependencies": {
         "@babel/core": "^7.21.3",
-        "@babel/plugin-proposal-class-properties": "^7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/plugin-transform-class-properties": "^7.23.3",
+        "@babel/plugin-transform-object-rest-spread": "^7.23.4",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/preset-env": "^7.20.2",
         <%_ if (react) { _%>

--- a/generators/app/templates/dotfiles/.babelrc
+++ b/generators/app/templates/dotfiles/.babelrc
@@ -7,7 +7,7 @@
   ],
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
-    "@babel/proposal-class-properties",
-    "@babel/proposal-object-rest-spread"
+    "@babel/plugin-transform-class-properties",
+    "@babel/plugin-transform-object-rest-spread"
   ]
 }


### PR DESCRIPTION
npm WARN deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.

npm WARN deprecated @babel/plugin-proposal-object-rest-spread@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.