### PR TITLE
if wp project, move top of navigation down by the height of the admin bar

### DIFF
--- a/generators/app/templates/static/scss/objects/_objects.navigation.scss
+++ b/generators/app/templates/static/scss/objects/_objects.navigation.scss
@@ -1,2 +1,7 @@
 .o-navigation {
+    position: fixed;
+    //if wp project, move top of navigation down by the height of the admin bar
+    top: var(--wp-admin--admin-bar--height, 0);
+    left: 0;
+    width: 100%;
 }

--- a/generators/app/templates/static/scss/objects/_objects.navigation.scss
+++ b/generators/app/templates/static/scss/objects/_objects.navigation.scss
@@ -1,7 +1,2 @@
 .o-navigation {
-    position: fixed;
-    //if wp project, move top of navigation down by the height of the admin bar
-    top: var(--wp-admin--admin-bar--height, 0);
-    left: 0;
-    width: 100%;
 }

--- a/generators/app/templates/static/scss/vendors/_vendors.index.scss
+++ b/generators/app/templates/static/scss/vendors/_vendors.index.scss
@@ -10,3 +10,4 @@
  */
 @import "vendors.swiper";
 @import "vendors.slim-select";
+@import "vendors.wordpress";

--- a/generators/app/templates/static/scss/vendors/_vendors.wordpress.scss
+++ b/generators/app/templates/static/scss/vendors/_vendors.wordpress.scss
@@ -1,0 +1,6 @@
+body.logged-in.admin-bar {
+    .o-navigation {
+        //if wp project, move top of navigation down by the height of the admin bar
+        top: var(--wp-admin--admin-bar--height, 0);
+    }
+}


### PR DESCRIPTION
Znaci primjer koda, ako je wp projekt i admin bar je ukljucen wp ce ispucati varijablu --wp-admin--admin-bar--height.
Tu varijablu dalje mozemo koristit kako nebi prekrivali admin bar
Kao fallback, (za ne loginane usere) koristim top: 0, kao i do sada

Primjer priora web, moguce vidjet na stagingu
![Screenshot 2024-02-23 at 15 33 09](https://github.com/bornfight/b-creative/assets/19188015/e1162aa4-d2c7-493f-88e3-0ac1cd5868e1)
